### PR TITLE
Fix mobile event dragging and resizing

### DIFF
--- a/Fbs.WebApp/pages/booking/new/index.vue
+++ b/Fbs.WebApp/pages/booking/new/index.vue
@@ -353,4 +353,8 @@ function onViewChange({ start, id }) {
 :deep(.vuecal__event-placeholder) {
   background-color: var(--p-primary-color);
 }
+
+:deep(.vuecal__event) {
+  touch-action: none;
+}
 </style>


### PR DESCRIPTION
This PR fixes an issue where users were unable to modify or update the time selection of a calendar event on mobile devices.

The `vue-cal` component uses drag events to manipulate calendar items. On touch screens, attempting to drag an event would trigger the browser's native scrolling behavior instead of the calendar's drag-and-drop logic. Adding `touch-action: none` to the `.vuecal__event` class prevents this browser interception, restoring the ability to move and resize events.

---
*PR created automatically by Jules for task [10031562932714001566](https://jules.google.com/task/10031562932714001566) started by @qin-guan*